### PR TITLE
fix: Update PeerDid resolver to support the multiple service individually encoded

### DIFF
--- a/lib/src/main/kotlin/org/didcommx/peerdid/PeerDIDCreator.kt
+++ b/lib/src/main/kotlin/org/didcommx/peerdid/PeerDIDCreator.kt
@@ -19,7 +19,7 @@ fun isPeerDID(peerDID: String): Boolean {
     val regex =
         (
             "^did:peer:(([0](z)([1-9a-km-zA-HJ-NP-Z]{46,47}))" +
-                "|(2((.[AEVID](z)([1-9a-km-zA-HJ-NP-Z]{46,47}))+(.(S)[0-9a-zA-Z=]*)?)))$"
+                "|(2((.[AEVID](z)([1-9a-km-zA-HJ-NP-Z]{46,47}))+(.(S)[0-9a-zA-Z=]*)*)))$"
             ).toRegex()
     return regex.matches(peerDID)
 }

--- a/lib/src/main/kotlin/org/didcommx/peerdid/PeerDIDResolver.kt
+++ b/lib/src/main/kotlin/org/didcommx/peerdid/PeerDIDResolver.kt
@@ -46,6 +46,7 @@ private fun buildDIDDocNumalgo2(peerDID: PeerDID, format: VerificationMaterialFo
     val keys = peerDID.drop(11)
 
     var service = ""
+    val encodedServicesJson = mutableListOf<JSON>()
     val authentications = mutableListOf<VerificationMethodPeerDID>()
     val keyAgreement = mutableListOf<VerificationMethodPeerDID>()
 
@@ -54,8 +55,9 @@ private fun buildDIDDocNumalgo2(peerDID: PeerDID, format: VerificationMaterialFo
         val value = it.drop(1)
 
         when (prefix) {
-            Numalgo2Prefix.SERVICE.prefix -> service = value
-
+            Numalgo2Prefix.SERVICE.prefix -> {
+                encodedServicesJson.add(value)
+            }
             Numalgo2Prefix.AUTHENTICATION.prefix -> {
                 val decodedEncumbasis = decodeMultibaseEncnumbasisAuth(value, format)
                 authentications.add(getVerificationMethod(peerDID, decodedEncumbasis))
@@ -70,7 +72,7 @@ private fun buildDIDDocNumalgo2(peerDID: PeerDID, format: VerificationMaterialFo
         }
     }
 
-    val decodedService = doDecodeService(service, peerDID)
+    val decodedService = doDecodeService(encodedServicesJson, peerDID)
 
     return DIDDocPeerDID(
         did = peerDID,
@@ -106,7 +108,7 @@ private fun decodeMultibaseEncnumbasisAgreement(
     }
 }
 
-private fun doDecodeService(service: String, peerDID: String): List<Service>? {
+private fun doDecodeService(service: List<JSON>, peerDID: String): List<Service>? {
     try {
         return decodeService(service, peerDID)
     } catch (e: IllegalArgumentException) {

--- a/lib/src/main/kotlin/org/didcommx/peerdid/core/PeerDIDHelper.kt
+++ b/lib/src/main/kotlin/org/didcommx/peerdid/core/PeerDIDHelper.kt
@@ -65,18 +65,28 @@ internal fun encodeService(service: JSON): String {
  * @throws IllegalArgumentException if service is not correctly decoded
  * @return decoded service
  */
-internal fun decodeService(encodedService: JSON, peerDID: PeerDID): List<Service>? {
-    if (encodedService.isEmpty())
+internal fun decodeService(encodedServices: List<JSON>, peerDID: PeerDID): List<Service>? {
+
+    if (encodedServices.isEmpty())
         return null
-    val decodedService = Base64.decodeBase64(encodedService).decodeToString()
+
+    val decodedServices = encodedServices.map { encodedService ->
+        Base64.decodeBase64(encodedService).decodeToString()
+    }
+
+    val decodedServicesJson = if (decodedServices.size == 1) {
+        decodedServices[0]
+    } else {
+        decodedServices.joinToString(separator = ",", prefix = "[", postfix = "]")
+    }
 
     val serviceMapList = try {
-        fromJsonToList(decodedService)
+        fromJsonToList(decodedServicesJson)
     } catch (e: JsonSyntaxException) {
         try {
-            listOf(fromJsonToMap(decodedService))
+            listOf(fromJsonToMap(decodedServicesJson))
         } catch (e: JsonSyntaxException) {
-            throw IllegalArgumentException("Invalid JSON $decodedService")
+            throw IllegalArgumentException("Invalid JSON $decodedServices")
         }
     }
 

--- a/lib/src/test/kotlin/org/didcommx/peerdid/Fixture.kt
+++ b/lib/src/test/kotlin/org/didcommx/peerdid/Fixture.kt
@@ -245,6 +245,57 @@ const val DID_DOC_NUMALGO_2_MULTIBASE_2_SERVICES = """
         }
     """
 
+const val PEER_DID_NUMALGO_2_2_ENCODED_SERVICES_INDIVIDUALLY = (
+    "did:peer:2" +
+        ".Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud" +
+        ".Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V" +
+        ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0K" +
+        ".SeyJ0IjoiZXhhbXBsZSIsInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50MiIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkyIl0sImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il19"
+    )
+const val DID_DOC_NUMALGO_2_MULTIBASE_2_SERVICES_INDIVIDUALLY = """
+        {
+          "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0K.SeyJ0IjoiZXhhbXBsZSIsInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50MiIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkyIl0sImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il19",
+          "authentication": [
+            {
+              "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0K.SeyJ0IjoiZXhhbXBsZSIsInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50MiIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkyIl0sImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il19#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+              "type": "Ed25519VerificationKey2020",
+              "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0K.SeyJ0IjoiZXhhbXBsZSIsInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50MiIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkyIl0sImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il19",
+              "publicKeyMultibase": "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+            }
+          ],
+          "keyAgreement": [
+            {
+              "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0K.SeyJ0IjoiZXhhbXBsZSIsInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50MiIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkyIl0sImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il19#6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud",
+              "type": "X25519KeyAgreementKey2020",
+              "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0K.SeyJ0IjoiZXhhbXBsZSIsInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50MiIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkyIl0sImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il19",
+              "publicKeyMultibase": "z6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud"
+            }
+          ],
+          "service": [
+            {
+              "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0K.SeyJ0IjoiZXhhbXBsZSIsInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50MiIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkyIl0sImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il19#didcommmessaging-0",
+              "type": "DIDCommMessaging",
+              "serviceEndpoint": "https://example.com/endpoint",
+              "routingKeys": [
+                "did:example:somemediator#somekey"
+              ]
+            },
+            {
+              "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0K.SeyJ0IjoiZXhhbXBsZSIsInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50MiIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkyIl0sImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il19#example-1",
+              "type": "example",
+              "serviceEndpoint": "https://example.com/endpoint2",
+              "routingKeys": [
+                "did:example:somemediator#somekey2"
+              ],
+              "accept": [
+                "didcomm/v2",
+                "didcomm/aip2;env=rfc587"
+              ]
+            }
+          ]
+        }
+    """
+
 const val PEER_DID_NUMALGO_2_NO_SERVICES = (
     "did:peer:2" +
         ".Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud" +

--- a/lib/src/test/kotlin/org/didcommx/peerdid/TestResolveNumalgo2.kt
+++ b/lib/src/test/kotlin/org/didcommx/peerdid/TestResolveNumalgo2.kt
@@ -38,6 +38,12 @@ class TestResolveNumalgo2 {
     }
 
     @Test
+    fun testResolvePositiveIndividuallyEncodedServiceIs2ElementsArray() {
+        val realValue = resolvePeerDID(PEER_DID_NUMALGO_2_2_ENCODED_SERVICES_INDIVIDUALLY)
+        assertEquals(fromJson(DID_DOC_NUMALGO_2_MULTIBASE_2_SERVICES_INDIVIDUALLY), fromJson(realValue))
+    }
+
+    @Test
     fun testResolvePositiveNoService() {
         val realValue = resolvePeerDID(PEER_DID_NUMALGO_2_NO_SERVICES)
         assertEquals(fromJson(DID_DOC_NUMALGO_2_MULTIBASE_NO_SERVICES), fromJson(realValue))

--- a/lib/src/test/kotlin/org/didcommx/peerdid/core/TestServiceEncodeDecode.kt
+++ b/lib/src/test/kotlin/org/didcommx/peerdid/core/TestServiceEncodeDecode.kt
@@ -38,7 +38,7 @@ class TestServiceEncodeDecode {
             )
         )
         val service = decodeService(
-            "eyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
+            listOf("eyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0"),
             PEER_DID_NUMALGO_2
         )
         assertEquals(expected, service)
@@ -71,7 +71,7 @@ class TestServiceEncodeDecode {
             )
         )
         val service = decodeService(
-            "eyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9",
+            listOf("eyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9"),
             PEER_DID_NUMALGO_2
         )
         assertEquals(expected, service)
@@ -123,7 +123,37 @@ class TestServiceEncodeDecode {
             )
         )
         val service = decodeService(
-            "W3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il0sImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il19LHsidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQyIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTIiXX1d",
+            listOf("W3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il0sImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il19LHsidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQyIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTIiXX1d"),
+            PEER_DID_NUMALGO_2
+        )
+        assertEquals(expected, service)
+    }
+    @Test
+    fun testDecodeServiceMultipleEntriesIndividualEncoded() {
+        val expected = listOf(
+            OtherService(
+                mapOf(
+                    "id" to "$PEER_DID_NUMALGO_2#didcommmessaging-0",
+                    "type" to "DIDCommMessaging",
+                    "serviceEndpoint" to "https://example.com/endpoint",
+                    "routingKeys" to listOf("did:example:somemediator#somekey"),
+                    "accept" to listOf("didcomm/v2", "didcomm/aip2;env=rfc587")
+                )
+            ),
+            OtherService(
+                mapOf(
+                    "id" to "$PEER_DID_NUMALGO_2#didcommmessaging-1",
+                    "type" to "DIDCommMessaging",
+                    "serviceEndpoint" to "https://example.com/endpoint2",
+                    "routingKeys" to listOf("did:example:somemediator#somekey2")
+                )
+            )
+        )
+        val service = decodeService(
+            listOf(
+                "eyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
+                "eyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdfQ"
+            ),
             PEER_DID_NUMALGO_2
         )
         assertEquals(expected, service)


### PR DESCRIPTION
The peer-did-jvm library currently does not correctly resolve peer DIDs that have multiple individually encoded services, as outlined in the peer DID specification. For instance, it cannot accurately handle DIDs similar to the example provided. 

did:peer:2.Vz6Mkj3PUd1WjvaDhNZhhhXQdz5UnZXmS7ehtx8bsPpD47kKc.Ez6LSg8zQom395jKLrGiBNruB9MM6V8PWuf2FpEy4uRFiqQBR.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHA6Ly9leGFtcGxlLmNvbS9kaWRjb21tIiwiYSI6WyJkaWRjb21tL3YyIl0sInIiOlsiZGlkOmV4YW1wbGU6MTIzNDU2Nzg5YWJjZGVmZ2hpI2tleS0xIl19fQ.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHA6Ly9leGFtcGxlLmNvbS9hbm90aGVyIiwiYSI6WyJkaWRjb21tL3YyIl0sInIiOlsiZGlkOmV4YW1wbGU6MTIzNDU2Nzg5YWJjZGVmZ2hpI2tleS0yIl19fQ

To address this issue, This PR updates the regex validation to support multiple services encoded separately. Additionally, it modifies the peer DID resolver to ensure correct resolution of such DIDs. 
This change aligns with the recent updates in the peer DID method specification, as seen in PR #67 on the  repository  
https://github.com/decentralized-identity/peer-did-method-spec/pull/67

These improvements are designed to enhance the library's functionality without breaking any existing behavior of the library. 

However, in future, I will raise a few more small PRs to align the library with the latest specifications.
https://identity.foundation/peer-did-method-spec