### PR TITLE
Update peer-did creation and resolution inline with peer-did spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,59 +69,152 @@ Example code:
     val didDocAlgo2 = DIDDocPeerDID.fromJson(didDocAlgo2Json)
 
 Example of DID documents:
+# DIDDoc algo 0:
+
+    {
+        "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+        "authentication": [
+            {
+                "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#key-1",
+                "type": "Ed25519VerificationKey2020",
+                "controller": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                "publicKeyMultibase": "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+            }
+        ]
+    }
+
+    # did_doc_algo_2
+    {
+        "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19",
+        "authentication": [
+            {
+                "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19#key-2",
+                "type": "Ed25519VerificationKey2020",
+                "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19",
+                "publicKeyMultibase": "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+            }
+        ],
+        "keyAgreement": [
+            {
+                "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19#key-1",
+                "type": "X25519KeyAgreementKey2020",
+                "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19",
+                "publicKeyMultibase": "z6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud"
+            }
+        ],
+        "service": [
+            {
+                "id": "#service",
+                "type": "DIDCommMessaging",
+                "serviceEndpoint": {
+                    "uri": "https://example.com/endpoint1",
+                    "routingKeys": [
+                        "did:example:somemediator#somekey1"
+                    ],
+                    "accept": [
+                        "didcomm/v2", "didcomm/aip2;env=rfc587"
+                    ]
+                }
+            }
+        ]
+    }
+
+
+Example code:
+    Based the new PeerDid Spec https://identity.foundation/peer-did-method-spec/
+
+    val encryptionKeys = listOf(
+        VerificationMaterialAgreement(
+            type = VerificationMethodTypeAgreement.X25519_KEY_AGREEMENT_KEY_2019,
+            format = VerificationMaterialFormatPeerDID.BASE58,
+            value = "DmgBSHMqaZiYqwNMEJJuxWzsGGC8jUYADrfSdBrC6L8s",
+        )
+    )
+    val signingKeys = listOf(
+        VerificationMaterialAuthentication(
+            type = VerificationMethodTypeAuthentication.ED25519_VERIFICATION_KEY_2018,
+            format = VerificationMaterialFormatPeerDID.BASE58,
+            value = "ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
+        )
+    )
+    val service =
+        """
+            {
+              "type": "DIDCommMessaging",
+              "serviceEndpoint": {
+                "uri": "https://example.com/endpoint1",
+                "routingKeys": [
+                  "did:example:somemediator#somekey1"
+                ],
+                "accept": [
+                  "didcomm/v2",
+                  "didcomm/aip2;env=rfc587"
+                ]
+              }
+            }
+        """
+
+    val peerDIDAlgo0 = createPeerDIDNumalgo0(signingKeys[0])
+    val peerDIDAlgo2 = createPeerDIDNumalgo2(
+        encryptionKeys, signingKeys, service
+    )
+
+    val didDocAlgo0Json = resolvePeerDID(peerDIDAlgo0)
+    val didDocAlgo2Json = resolvePeerDID(peerDIDAlgo2)
+
+    val didDocAlgo0 = DIDDocPeerDID.fromJson(didDocAlgo0Json)
+    val didDocAlgo2 = DIDDocPeerDID.fromJson(didDocAlgo2Json)
+
+Example of DID documents:
 
     # DIDDoc algo 0:
     {
         "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
         "authentication": [
             {
-                "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
-                "type": "Ed25519VerificationKey2020",
-                "controller": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
-                "publicKeyMultibase": "ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"
+              "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#key-1",
+              "type": "Ed25519VerificationKey2020",
+              "controller": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+              "publicKeyMultibase": "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
             }
         ]
     }
 
     # did_doc_algo_2
-        {
-           "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
-           "authentication": [
-               {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
-                   "type": "Ed25519VerificationKey2020",
-                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
-                   "publicKeyMultibase": "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
-               },
-               {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg",
-                   "type": "Ed25519VerificationKey2020",
-                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
-                   "publicKeyMultibase": "z6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg"
-               }
-           ],
-           "keyAgreement": [
-               {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
-                   "type": "X25519KeyAgreementKey2020",
-                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
-                   "publicKeyMultibase": "z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc"
-               }
-           ],
-           "service": [
-               {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#didcommmessaging-0",
-                   "type": "DIDCommMessaging",
-                   "serviceEndpoint": "https://example.com/endpoint",
-                   "routingKeys": [
-                       "did:example:somemediator#somekey"
-                   ],
-                   "accept": [
+    {
+        "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19",
+        "authentication": [
+            {
+                "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19#key-2",
+                "type": "Ed25519VerificationKey2020",
+                "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19",
+                "publicKeyMultibase": "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+            }
+        ],
+        "keyAgreement": [
+            {
+                "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19#key-1",
+                "type": "X25519KeyAgreementKey2020",
+                "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19",
+                "publicKeyMultibase": "z6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud"
+            }
+        ],
+        "service": [
+            {
+                "id": "#service",
+                "type": "DIDCommMessaging",
+                "serviceEndpoint": {
+                    "uri": "https://example.com/endpoint1",
+                    "routingKeys": [
+                        "did:example:somemediator#somekey1"
+                    ],
+                    "accept": [
                         "didcomm/v2", "didcomm/aip2;env=rfc587"
-                   ]
-               }
-           ]
-       }
+                    ]
+                }
+            }
+        ]
+    }
 
 ## Assumptions and limitations
 - Only static layers [1, 2a, 2b](https://identity.foundation/peer-did-method-spec/#layers-of-support) are supported

--- a/lib/src/main/kotlin/org/didcommx/peerdid/DIDDoc.kt
+++ b/lib/src/main/kotlin/org/didcommx/peerdid/DIDDoc.kt
@@ -88,25 +88,29 @@ data class VerificationMethodPeerDID(
 
 sealed interface Service
 
+data class ServiceEndpoint(
+    val uri: String,
+    val routingKeys: List<String>,
+    val accept: List<String>
+)
 data class OtherService(val data: Map<String, Any>) : Service
 
 data class DIDCommServicePeerDID(
     val id: String,
     val type: String,
-    val serviceEndpoint: String,
-    val routingKeys: List<String>,
-    val accept: List<String>
+    val serviceEndpoint: ServiceEndpoint,
 ) : Service {
 
-    fun toDict(): MutableMap<String, Any> {
-        val res = mutableMapOf<String, Any>(
+    fun toDict(): Map<String, Any> {
+        return mapOf(
             SERVICE_ID to id,
             SERVICE_TYPE to type,
+            SERVICE_ENDPOINT to mapOf(
+                SERVICE_URI to serviceEndpoint.uri,
+                SERVICE_ROUTING_KEYS to serviceEndpoint.routingKeys,
+                SERVICE_ACCEPT to serviceEndpoint.accept
+            )
         )
-        res[SERVICE_ENDPOINT] = serviceEndpoint
-        res[SERVICE_ROUTING_KEYS] = routingKeys
-        res[SERVICE_ACCEPT] = accept
-        return res
     }
 }
 
@@ -122,3 +126,4 @@ const val SERVICE_ENDPOINT = "serviceEndpoint"
 const val SERVICE_DIDCOMM_MESSAGING = "DIDCommMessaging"
 const val SERVICE_ROUTING_KEYS = "routingKeys"
 const val SERVICE_ACCEPT = "accept"
+const val SERVICE_URI = "uri"

--- a/lib/src/main/kotlin/org/didcommx/peerdid/PeerDIDResolver.kt
+++ b/lib/src/main/kotlin/org/didcommx/peerdid/PeerDIDResolver.kt
@@ -38,7 +38,7 @@ private fun buildDIDDocNumalgo0(peerDID: PeerDID, format: VerificationMaterialFo
     val decodedEncumbasis = decodeMultibaseEncnumbasisAuth(inceptionKey, format)
     return DIDDocPeerDID(
         did = peerDID,
-        authentication = listOf(getVerificationMethod(peerDID, decodedEncumbasis))
+        authentication = listOf(getVerificationMethod(1, peerDID, decodedEncumbasis))
     )
 }
 
@@ -49,9 +49,9 @@ private fun buildDIDDocNumalgo2(peerDID: PeerDID, format: VerificationMaterialFo
     val authentications = mutableListOf<VerificationMethodPeerDID>()
     val keyAgreement = mutableListOf<VerificationMethodPeerDID>()
 
-    keys.split(".").forEach {
-        val prefix = it[0]
-        val value = it.drop(1)
+    keys.split(".").withIndex().forEach { (index, keyIt) ->
+        val prefix = keyIt[0]
+        val value = keyIt.drop(1)
 
         when (prefix) {
             Numalgo2Prefix.SERVICE.prefix -> {
@@ -59,12 +59,12 @@ private fun buildDIDDocNumalgo2(peerDID: PeerDID, format: VerificationMaterialFo
             }
             Numalgo2Prefix.AUTHENTICATION.prefix -> {
                 val decodedEncumbasis = decodeMultibaseEncnumbasisAuth(value, format)
-                authentications.add(getVerificationMethod(peerDID, decodedEncumbasis))
+                authentications.add(getVerificationMethod(index + 1, peerDID, decodedEncumbasis))
             }
 
             Numalgo2Prefix.KEY_AGREEMENT.prefix -> {
                 val decodedEncumbasis = decodeMultibaseEncnumbasisAgreement(value, format)
-                keyAgreement.add(getVerificationMethod(peerDID, decodedEncumbasis))
+                keyAgreement.add(getVerificationMethod(index + 1, peerDID, decodedEncumbasis))
             }
 
             else -> throw IllegalArgumentException("Unsupported transform part of PeerDID: $prefix")

--- a/lib/src/main/kotlin/org/didcommx/peerdid/core/DIDDocHelper.kt
+++ b/lib/src/main/kotlin/org/didcommx/peerdid/core/DIDDocHelper.kt
@@ -5,13 +5,12 @@ import org.didcommx.peerdid.DIDCommServicePeerDID
 import org.didcommx.peerdid.DIDDocPeerDID
 import org.didcommx.peerdid.OtherService
 import org.didcommx.peerdid.PublicKeyField
-import org.didcommx.peerdid.SERVICE_ACCEPT
 import org.didcommx.peerdid.SERVICE_DIDCOMM_MESSAGING
 import org.didcommx.peerdid.SERVICE_ENDPOINT
 import org.didcommx.peerdid.SERVICE_ID
-import org.didcommx.peerdid.SERVICE_ROUTING_KEYS
 import org.didcommx.peerdid.SERVICE_TYPE
 import org.didcommx.peerdid.Service
+import org.didcommx.peerdid.ServiceEndpoint
 import org.didcommx.peerdid.VerificationMaterialFormatPeerDID
 import org.didcommx.peerdid.VerificationMaterialPeerDID
 import org.didcommx.peerdid.VerificationMethodPeerDID
@@ -100,16 +99,21 @@ internal fun serviceFromJson(jsonObject: JsonObject): Service {
     if (type != SERVICE_DIDCOMM_MESSAGING)
         return OtherService(serviceMap)
 
-    val endpoint = jsonObject.get(SERVICE_ENDPOINT)?.asString
-    val routingKeys = jsonObject.get(SERVICE_ROUTING_KEYS)?.asJsonArray?.map { it.asString }
-    val accept = jsonObject.get(SERVICE_ACCEPT)?.asJsonArray?.map { it.asString }
+    val serviceEndpointObject = jsonObject.getAsJsonObject(SERVICE_ENDPOINT)
+    val uri = serviceEndpointObject?.get("uri")?.asString ?: ""
+    val routingKeys = serviceEndpointObject?.getAsJsonArray("routingKeys")?.map { it.asString } ?: emptyList()
+    val accept = serviceEndpointObject?.getAsJsonArray("accept")?.map { it.asString } ?: emptyList()
+
+    val serviceEndpoint = ServiceEndpoint(
+        uri = uri,
+        routingKeys = routingKeys,
+        accept = accept
+    )
 
     return DIDCommServicePeerDID(
         id = id,
         type = type,
-        serviceEndpoint = endpoint ?: "",
-        routingKeys = routingKeys ?: emptyList(),
-        accept = accept ?: emptyList()
+        serviceEndpoint = serviceEndpoint
     )
 }
 

--- a/lib/src/test/kotlin/org/didcommx/peerdid/Fixture.kt
+++ b/lib/src/test/kotlin/org/didcommx/peerdid/Fixture.kt
@@ -13,7 +13,7 @@ const val DID_DOC_NUMALGO_O_BASE58 = """
            "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
            "authentication": [
                {
-                   "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                   "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#key-1",
                    "type": "Ed25519VerificationKey2018",
                    "controller": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
                    "publicKeyBase58": "ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"
@@ -27,7 +27,7 @@ const val DID_DOC_NUMALGO_O_MULTIBASE = """
            "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
            "authentication": [
                {
-                   "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                   "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#key-1",
                    "type": "Ed25519VerificationKey2020",
                    "controller": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
                    "publicKeyMultibase": "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
@@ -41,7 +41,7 @@ const val DID_DOC_NUMALGO_O_JWK = """
             "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
             "authentication": [
                 {
-                    "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                    "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#key-1",
                     "type": "JsonWebKey2020",
                     "controller": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
                     "publicKeyJwk": {
@@ -67,13 +67,13 @@ const val DID_DOC_NUMALGO_2_BASE58 = """
            "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
            "authentication": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#key-2",
                    "type": "Ed25519VerificationKey2018",
                    "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
                    "publicKeyBase58": "ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"
                },
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#key-3",
                    "type": "Ed25519VerificationKey2018",
                    "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
                    "publicKeyBase58": "3M5RCDjPTWPkKSN3sxUmmMqHbmRPegYP1tjcKyrDbt9J"
@@ -81,7 +81,7 @@ const val DID_DOC_NUMALGO_2_BASE58 = """
            ],
            "keyAgreement": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#key-1",
                    "type": "X25519KeyAgreementKey2019",
                    "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
                    "publicKeyBase58": "JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr"
@@ -89,15 +89,15 @@ const val DID_DOC_NUMALGO_2_BASE58 = """
            ],
            "service": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#didcommmessaging-0",
-                   "type": "DIDCommMessaging",
-                   "serviceEndpoint": "https://example.com/endpoint",
-                   "routingKeys": [
-                       "did:example:somemediator#somekey"
-                   ],
-                   "accept": [
-                        "didcomm/v2", "didcomm/aip2;env=rfc587"
-                   ]
+                    "id": "#service",
+                    "type": "DIDCommMessaging",
+                    "serviceEndpoint": { 
+                        "uri": "https://example.com/endpoint",
+                        "routingKeys": [
+                            "did:example:somemediator#somekey"
+                        ],
+                        "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"]
+                   } 
                }
            ]
        }
@@ -108,13 +108,13 @@ const val DID_DOC_NUMALGO_2_MULTIBASE = """
            "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
            "authentication": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#key-2",
                    "type": "Ed25519VerificationKey2020",
                    "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
                    "publicKeyMultibase": "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
                },
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#key-3",
                    "type": "Ed25519VerificationKey2020",
                    "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
                    "publicKeyMultibase": "z6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg"
@@ -122,7 +122,7 @@ const val DID_DOC_NUMALGO_2_MULTIBASE = """
            ],
            "keyAgreement": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#key-1",
                    "type": "X25519KeyAgreementKey2020",
                    "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
                    "publicKeyMultibase": "z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc"
@@ -130,15 +130,15 @@ const val DID_DOC_NUMALGO_2_MULTIBASE = """
            ],
            "service": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#didcommmessaging-0",
-                   "type": "DIDCommMessaging",
-                   "serviceEndpoint": "https://example.com/endpoint",
-                   "routingKeys": [
-                       "did:example:somemediator#somekey"
-                   ],
-                   "accept": [
-                        "didcomm/v2", "didcomm/aip2;env=rfc587"
-                   ]
+                    "id": "#service",
+                    "type": "DIDCommMessaging",
+                    "serviceEndpoint": { 
+                        "uri": "https://example.com/endpoint",
+                        "routingKeys": [
+                            "did:example:somemediator#somekey"
+                        ],
+                        "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"]
+                   } 
                }
            ]
        }
@@ -149,7 +149,7 @@ const val DID_DOC_NUMALGO_2_JWK = """
            "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
            "authentication": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#key-2",
                    "type": "JsonWebKey2020",
                    "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
                     "publicKeyJwk": {
@@ -159,7 +159,7 @@ const val DID_DOC_NUMALGO_2_JWK = """
                      }
                },
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#key-3",
                    "type": "JsonWebKey2020",
                    "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
                     "publicKeyJwk": {
@@ -171,7 +171,7 @@ const val DID_DOC_NUMALGO_2_JWK = """
            ],
            "keyAgreement": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#key-1",
                    "type": "JsonWebKey2020",
                    "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
                     "publicKeyJwk": {
@@ -183,15 +183,15 @@ const val DID_DOC_NUMALGO_2_JWK = """
            ],
            "service": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#didcommmessaging-0",
-                   "type": "DIDCommMessaging",
-                   "serviceEndpoint": "https://example.com/endpoint",
-                   "routingKeys": [
-                       "did:example:somemediator#somekey"
-                   ],
-                   "accept": [
-                        "didcomm/v2", "didcomm/aip2;env=rfc587"
-                   ]
+                    "id": "#service",
+                    "type": "DIDCommMessaging",
+                    "serviceEndpoint": { 
+                        "uri": "https://example.com/endpoint",
+                        "routingKeys": [
+                            "did:example:somemediator#somekey"
+                        ],
+                        "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"]
+                   } 
                }
            ]
        }
@@ -209,7 +209,7 @@ const val DID_DOC_NUMALGO_2_MULTIBASE_2_SERVICES = """
             "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0",
             "authentication": [
                 {
-                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0#key-2",
                     "type": "Ed25519VerificationKey2020",
                     "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0",
                     "publicKeyMultibase": "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
@@ -217,7 +217,7 @@ const val DID_DOC_NUMALGO_2_MULTIBASE_2_SERVICES = """
             ],
             "keyAgreement": [
                 {
-                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0#6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud",
+                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0#key-1",
                     "type": "X25519KeyAgreementKey2020",
                     "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0",
                     "publicKeyMultibase": "z6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud"
@@ -225,21 +225,25 @@ const val DID_DOC_NUMALGO_2_MULTIBASE_2_SERVICES = """
             ],
             "service": [
                 {
-                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0#didcommmessaging-0",
+                    "id": "#service",
                     "type": "DIDCommMessaging",
-                    "serviceEndpoint": "https://example.com/endpoint",
-                    "routingKeys": [
+                    "serviceEndpoint": {
+                        "uri": "https://example.com/endpoint",
+                        "routingKeys": [
                         "did:example:somemediator#somekey"
-                    ]
+                        ]
+                    }
                 },
                 {
-                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0#example-1",
+                    "id": "#service-1",
                     "type": "example",
-                    "serviceEndpoint": "https://example.com/endpoint2",
-                    "routingKeys": [
-                        "did:example:somemediator#somekey2"
-                    ],
-                    "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"]
+                    "serviceEndpoint": { 
+                        "uri": "https://example.com/endpoint2",
+                        "routingKeys": [
+                            "did:example:somemediator#somekey2"
+                        ],
+                        "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"]
+                   } 
                 }
             ]
         }
@@ -257,7 +261,7 @@ const val DID_DOC_NUMALGO_2_MULTIBASE_2_SERVICES_INDIVIDUALLY = """
           "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0K.SeyJ0IjoiZXhhbXBsZSIsInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50MiIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkyIl0sImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il19",
           "authentication": [
             {
-              "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0K.SeyJ0IjoiZXhhbXBsZSIsInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50MiIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkyIl0sImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il19#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+              "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0K.SeyJ0IjoiZXhhbXBsZSIsInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50MiIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkyIl0sImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il19#key-2",
               "type": "Ed25519VerificationKey2020",
               "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0K.SeyJ0IjoiZXhhbXBsZSIsInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50MiIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkyIl0sImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il19",
               "publicKeyMultibase": "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
@@ -265,7 +269,7 @@ const val DID_DOC_NUMALGO_2_MULTIBASE_2_SERVICES_INDIVIDUALLY = """
           ],
           "keyAgreement": [
             {
-              "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0K.SeyJ0IjoiZXhhbXBsZSIsInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50MiIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkyIl0sImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il19#6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud",
+              "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0K.SeyJ0IjoiZXhhbXBsZSIsInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50MiIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkyIl0sImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il19#key-1",
               "type": "X25519KeyAgreementKey2020",
               "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0K.SeyJ0IjoiZXhhbXBsZSIsInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50MiIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkyIl0sImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il19",
               "publicKeyMultibase": "z6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud"
@@ -273,24 +277,25 @@ const val DID_DOC_NUMALGO_2_MULTIBASE_2_SERVICES_INDIVIDUALLY = """
           ],
           "service": [
             {
-              "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0K.SeyJ0IjoiZXhhbXBsZSIsInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50MiIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkyIl0sImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il19#didcommmessaging-0",
-              "type": "DIDCommMessaging",
-              "serviceEndpoint": "https://example.com/endpoint",
-              "routingKeys": [
-                "did:example:somemediator#somekey"
-              ]
+                "id": "#service",
+                "type": "DIDCommMessaging",
+                "serviceEndpoint": {
+                    "uri": "https://example.com/endpoint",
+                    "routingKeys": [
+                    "did:example:somemediator#somekey"
+                    ]
+                }
             },
             {
-              "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0K.SeyJ0IjoiZXhhbXBsZSIsInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50MiIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkyIl0sImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il19#example-1",
-              "type": "example",
-              "serviceEndpoint": "https://example.com/endpoint2",
-              "routingKeys": [
-                "did:example:somemediator#somekey2"
-              ],
-              "accept": [
-                "didcomm/v2",
-                "didcomm/aip2;env=rfc587"
-              ]
+                "id": "#service-1",
+                "type": "example",
+                "serviceEndpoint": { 
+                    "uri": "https://example.com/endpoint2",
+                    "routingKeys": [
+                        "did:example:somemediator#somekey2"
+                    ],
+                    "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"]
+               } 
             }
           ]
         }
@@ -307,7 +312,7 @@ const val DID_DOC_NUMALGO_2_MULTIBASE_NO_SERVICES = """
             "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
             "authentication": [
                 {
-                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#key-2",
                     "type": "Ed25519VerificationKey2020",
                     "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
                     "publicKeyMultibase": "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
@@ -315,7 +320,7 @@ const val DID_DOC_NUMALGO_2_MULTIBASE_NO_SERVICES = """
             ],
             "keyAgreement": [
                 {
-                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud",
+                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#key-1",
                     "type": "X25519KeyAgreementKey2020",
                     "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
                     "publicKeyMultibase": "z6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud"
@@ -331,13 +336,13 @@ const val DID_DOC_NUMALGO_2_MULTIBASE_MINIMAL_SERVICES = """
            "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9",
            "authentication": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9#key-2",
                    "type": "Ed25519VerificationKey2020",
                    "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9",
                    "publicKeyMultibase": "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
                },
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9#6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9#key-3",
                    "type": "Ed25519VerificationKey2020",
                    "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9",
                    "publicKeyMultibase": "z6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg"
@@ -345,7 +350,7 @@ const val DID_DOC_NUMALGO_2_MULTIBASE_MINIMAL_SERVICES = """
            ],
            "keyAgreement": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9#6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9#key-1",
                    "type": "X25519KeyAgreementKey2020",
                    "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9",
                    "publicKeyMultibase": "z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc"
@@ -353,10 +358,12 @@ const val DID_DOC_NUMALGO_2_MULTIBASE_MINIMAL_SERVICES = """
            ],
            "service": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9#didcommmessaging-0",
-                   "serviceEndpoint": "https://example.com/endpoint",
-                   "type": "DIDCommMessaging"
-               }
+                    "id": "#service",
+                    "type": "DIDCommMessaging",
+                    "serviceEndpoint": {
+                        "uri": "https://example.com/endpoint"
+                    }
+                }
            ]
        }
     """

--- a/lib/src/test/kotlin/org/didcommx/peerdid/TestCreateNumalgo2.kt
+++ b/lib/src/test/kotlin/org/didcommx/peerdid/TestCreateNumalgo2.kt
@@ -154,6 +154,43 @@ class TestCreateNumalgo2 {
         assert(isPeerDID(peerDIDAlgo2))
     }
 
+    @ParameterizedTest
+    @MethodSource("validKeys")
+    fun testCreateNumalgo2PositiveServicesIndividuallyEncoded(keys: TestData) {
+        val service = """[
+            {
+                "type": "DIDCommMessaging",
+                "serviceEndpoint": { 
+                    "uri" : "https://example.com/endpoint",
+                    "routingKeys": ["did:example:somemediator#somekey"]
+                }    
+            },
+            {
+                "type": "example",
+                "serviceEndpoint": { 
+                    "uri" : "https://example.com/endpoint2",
+                    "routingKeys": ["did:example:somemediator#somekey2"],
+                    "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"]
+                }
+            }
+            ]
+            """
+
+        val peerDIDAlgo2 = createPeerDIDNumalgo2(
+            encryptionKeys = keys.encKeys, signingKeys = keys.signingKeys,
+            service = service
+        )
+        assertEquals(
+            "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc" +
+                ".Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V" +
+                ".Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg" +
+                ".SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19fQ" +
+                ".SeyJ0IjoiZXhhbXBsZSIsInMiOnsidXJpIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfX0",
+            peerDIDAlgo2
+        )
+        assert(isPeerDID(peerDIDAlgo2))
+    }
+
     @Test
     fun testCreateNumalgo2PositiveServiceNotArray() {
         val encryptionKeys = listOf(VALID_X25519_KEY_MULTIBASE)
@@ -164,6 +201,28 @@ class TestCreateNumalgo2 {
                 "type": "DIDCommMessaging",
                 "serviceEndpoint": "https://example.com/endpoint",
                 "routingKeys": ["did:example:somemediator#somekey"]
+            }
+            """
+
+        val peerDIDAlgo2 = createPeerDIDNumalgo2(
+            encryptionKeys = encryptionKeys, signingKeys = signingKeys,
+            service = service
+        )
+
+        assert(isPeerDID(peerDIDAlgo2))
+    }
+    @Test
+    fun testCreateNumalgo2PositiveServiceNotArrayWithServiceEndpointAsJson() {
+        val encryptionKeys = listOf(VALID_X25519_KEY_MULTIBASE)
+        val signingKeys = listOf(VALID_ED25519_KEY_1_MULTIBASE, VALID_ED25519_KEY_2_MULTIBASE)
+        val service =
+            """
+            {
+                "type": "DIDCommMessaging",
+                "serviceEndpoint": {
+                "uri": "https://example.com/endpoint",
+                "routingKeys": ["did:example:somemediator#somekey"]
+                }
             }
             """
 
@@ -197,6 +256,29 @@ class TestCreateNumalgo2 {
     }
 
     @Test
+    fun testCreateNumalgo2PositiveServiceMinimalFieldsWithServiceEndpointAsJson() {
+        val encryptionKeys = listOf(VALID_X25519_KEY_MULTIBASE)
+        val signingKeys = listOf(VALID_ED25519_KEY_1_MULTIBASE, VALID_ED25519_KEY_2_MULTIBASE)
+
+        val service =
+            """
+            {
+                "type": "DIDCommMessaging",
+                "serviceEndpoint": { 
+                    "uri": "https://example.com/endpoint"
+                }
+            }
+            """
+
+        val peerDIDAlgo2 = createPeerDIDNumalgo2(
+            encryptionKeys = encryptionKeys, signingKeys = signingKeys,
+            service = service
+        )
+
+        assert(isPeerDID(peerDIDAlgo2))
+    }
+
+    @Test
     fun testCreateNumalgo2PositiveServiceArrayOf1Element() {
         val encryptionKeys = listOf(VALID_X25519_KEY_MULTIBASE)
         val signingKeys = listOf(VALID_ED25519_KEY_1_MULTIBASE, VALID_ED25519_KEY_2_MULTIBASE)
@@ -218,7 +300,104 @@ class TestCreateNumalgo2 {
 
         assert(isPeerDID(peerDIDAlgo2))
     }
+    @Test
+    fun testCreateNumalgo2PositiveServiceArrayOf1ElementWithServiceEndpointAsJson() {
+        val encryptionKeys = listOf(VALID_X25519_KEY_MULTIBASE)
+        val signingKeys = listOf(VALID_ED25519_KEY_1_MULTIBASE, VALID_ED25519_KEY_2_MULTIBASE)
 
+        val service = """
+        [
+            {
+                "type": "DIDCommMessaging",
+                "serviceEndpoint": {
+                "uri": "https://example.com/endpoint",
+                "routingKeys": ["did:example:somemediator#somekey"]
+                }
+            }    
+        ]
+        """
+
+        val peerDIDAlgo2 = createPeerDIDNumalgo2(
+            encryptionKeys = encryptionKeys, signingKeys = signingKeys,
+            service = service
+        )
+
+        assert(isPeerDID(peerDIDAlgo2))
+    }
+    @Test
+    /**
+     * @see https://identity.foundation/peer-did-method-spec/#method-2-multiple-inception-key-without-doc
+     * */
+    fun testCreateNumalgo2PositiveServiceArrayOf1ElementUsingNewPeerDidSpec() {
+        val encryptionKeys = listOf(VALID_X25519_KEY_MULTIBASE)
+        val signingKeys = listOf(VALID_ED25519_KEY_1_MULTIBASE, VALID_ED25519_KEY_2_MULTIBASE)
+
+        val service = """
+        [
+          {
+          "type": "DIDCommMessaging",
+          "serviceEndpoint": {
+            "uri": "http://example.com/didcomm",
+            "accept": [
+              "didcomm/v2"
+            ],
+            "routingKeys": [
+              "did:example:123456789abcdefghi#key-1"
+            ]
+          }
+          }    
+        ]
+        """
+
+        val peerDIDAlgo2 = createPeerDIDNumalgo2(
+            encryptionKeys = encryptionKeys, signingKeys = signingKeys,
+            service = service
+        )
+
+        assert(isPeerDID(peerDIDAlgo2))
+    }
+    @Test
+    /**
+     * @see https://identity.foundation/peer-did-method-spec/#method-2-multiple-inception-key-without-doc
+     * */
+    fun testCreateNumalgo2PositiveServiceArrayOfMoreThen1ElementUsingNewPeerDidSpec() {
+        val encryptionKeys = listOf(VALID_X25519_KEY_MULTIBASE)
+        val signingKeys = listOf(VALID_ED25519_KEY_1_MULTIBASE, VALID_ED25519_KEY_2_MULTIBASE)
+
+        val service = """
+        [
+          {
+          "type": "DIDCommMessaging",
+          "serviceEndpoint": {
+            "uri": "http://example.com/didcomm",
+            "accept": [
+              "didcomm/v2"
+            ],
+            "routingKeys": [
+              "did:example:123456789abcdefghi#key-1"
+            ]
+          }
+          },
+          {
+          "type": "example",
+          "serviceEndpoint": {
+            "uri": "http://example.com/didcomm",
+            "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"],
+            "routingKeys": [
+              "did:example:123456789abcdefghi#key-2"
+            ]
+          }
+          }    
+        ]
+        """
+
+        val peerDIDAlgo2 = createPeerDIDNumalgo2(
+            encryptionKeys = encryptionKeys, signingKeys = signingKeys,
+            service = service
+        )
+
+        assert(isPeerDID(peerDIDAlgo2))
+    }
     @Test
     fun testCreateNumalgo2PositiveServiceIsNull() {
         val encryptionKeys = listOf(VALID_X25519_KEY_MULTIBASE)

--- a/lib/src/test/kotlin/org/didcommx/peerdid/TestDIDDocFromJson.kt
+++ b/lib/src/test/kotlin/org/didcommx/peerdid/TestDIDDocFromJson.kt
@@ -136,13 +136,14 @@ class TestDIDDocFromJson {
 
         val service = didDoc.service!![0]
         val expectedService = (fromJson(testData.didDoc)["service"] as List<Map<String, Any>>)[0]
+
         assertTrue(service is DIDCommServicePeerDID)
         assertEquals(expectedService["id"], service.id)
-        assertEquals(expectedService["serviceEndpoint"], service.serviceEndpoint)
         assertEquals(expectedService["type"], service.type)
-        assertEquals(expectedService["routingKeys"], service.routingKeys)
-        assertEquals(expectedService["accept"], service.accept)
-
+        val expectedServiceEndpoint = expectedService["serviceEndpoint"] as Map<String, Any>
+        assertEquals(expectedServiceEndpoint["uri"], service.serviceEndpoint.uri)
+        assertEquals(expectedServiceEndpoint["routingKeys"], service.serviceEndpoint.routingKeys)
+        assertEquals(expectedServiceEndpoint["accept"], service.serviceEndpoint.accept)
         assertEquals(listOf(expectedAuth1["id"], expectedAuth2["id"]), didDoc.authenticationKids)
         assertEquals(listOf(expectedAgreem["id"]), didDoc.agreementKids)
     }
@@ -161,10 +162,11 @@ class TestDIDDocFromJson {
             (fromJson(DID_DOC_NUMALGO_2_MULTIBASE_2_SERVICES)["service"] as List<Map<String, Any>>)[0]
         assertTrue(service1 is DIDCommServicePeerDID)
         assertEquals(expectedService1["id"], service1.id)
-        assertEquals(expectedService1["serviceEndpoint"], service1.serviceEndpoint)
         assertEquals(expectedService1["type"], service1.type)
-        assertEquals(expectedService1["routingKeys"], service1.routingKeys)
-        assertTrue(service1.accept.isEmpty())
+        val expectedServiceEndpoint1 = expectedService1["serviceEndpoint"] as Map<String, Any>
+        assertEquals(expectedServiceEndpoint1["uri"], service1.serviceEndpoint.uri)
+        assertEquals(expectedServiceEndpoint1["routingKeys"], service1.serviceEndpoint.routingKeys)
+        assertTrue(service1.serviceEndpoint.accept.isEmpty())
 
         val service2 = didDoc.service!![1]
         val expectedService2 =
@@ -193,13 +195,13 @@ class TestDIDDocFromJson {
         val service = didDoc.service!![0]
         assertTrue(service is DIDCommServicePeerDID)
         assertEquals(
-            "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9#didcommmessaging-0",
+            "#service",
             service.id
         )
-        assertEquals("https://example.com/endpoint", service.serviceEndpoint)
+        assertEquals("https://example.com/endpoint", service.serviceEndpoint.uri)
         assertEquals("DIDCommMessaging", service.type)
-        assertTrue(service.routingKeys.isEmpty())
-        assertTrue(service.accept.isEmpty())
+        assertTrue(service.serviceEndpoint.routingKeys.isEmpty())
+        assertTrue(service.serviceEndpoint.accept.isEmpty())
     }
 
     @Test

--- a/lib/src/test/kotlin/org/didcommx/peerdid/TestDemo.kt
+++ b/lib/src/test/kotlin/org/didcommx/peerdid/TestDemo.kt
@@ -51,4 +51,62 @@ class TestDemo {
         println("==================================")
         print("DIDDoc algo 2:${didDocAlgo2.toDict()}")
     }
+    @Test
+    /**
+     * @see https://identity.foundation/peer-did-method-spec/
+     */
+    fun testCreateResolvePeerDIDWithNewPeerDidSpec() {
+        val encryptionKeys = listOf(
+            VerificationMaterialAgreement(
+                type = VerificationMethodTypeAgreement.X25519_KEY_AGREEMENT_KEY_2019,
+                format = VerificationMaterialFormatPeerDID.BASE58,
+                value = "DmgBSHMqaZiYqwNMEJJuxWzsGGC8jUYADrfSdBrC6L8s",
+            )
+        )
+        val signingKeys = listOf(
+            VerificationMaterialAuthentication(
+                type = VerificationMethodTypeAuthentication.ED25519_VERIFICATION_KEY_2018,
+                format = VerificationMaterialFormatPeerDID.BASE58,
+                value = "ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
+            )
+        )
+        val service =
+            """
+                {
+                  "type": "DIDCommMessaging",
+                  "serviceEndpoint": {
+                    "uri": "https://example.com/endpoint1",
+                    "routingKeys": [
+                      "did:example:somemediator#somekey1"
+                    ],
+                    "accept": [
+                      "didcomm/v2",
+                      "didcomm/aip2;env=rfc587"
+                    ]
+                  }
+                }
+            """
+
+        val peerDIDAlgo0 = createPeerDIDNumalgo0(signingKeys[0])
+        val peerDIDAlgo2 = createPeerDIDNumalgo2(
+            encryptionKeys, signingKeys, service
+        )
+
+        println("PeerDID algo 0:$peerDIDAlgo0")
+        println("==================================")
+        println("PeerDID algo 2:$peerDIDAlgo2")
+        println("==================================")
+
+        val didDocAlgo0Json = resolvePeerDID(peerDIDAlgo0)
+        val didDocAlgo2Json = resolvePeerDID(peerDIDAlgo2)
+        println("DIDDoc algo 0:$didDocAlgo0Json")
+        println("==================================")
+        print("DIDDoc algo 2:$didDocAlgo2Json")
+
+        val didDocAlgo0 = DIDDocPeerDID.fromJson(didDocAlgo0Json)
+        val didDocAlgo2 = DIDDocPeerDID.fromJson(didDocAlgo2Json)
+        println("DIDDoc algo 0:${didDocAlgo0.toDict()}")
+        println("==================================")
+        print("DIDDoc algo 2:${didDocAlgo2.toDict()}")
+    }
 }

--- a/lib/src/test/kotlin/org/didcommx/peerdid/core/TestServiceEncodeDecode.kt
+++ b/lib/src/test/kotlin/org/didcommx/peerdid/core/TestServiceEncodeDecode.kt
@@ -29,19 +29,45 @@ class TestServiceEncodeDecode {
         val expected = listOf(
             OtherService(
                 mapOf(
-                    "id" to "$PEER_DID_NUMALGO_2#didcommmessaging-0",
+                    "id" to "#service",
                     "type" to "DIDCommMessaging",
-                    "serviceEndpoint" to "https://example.com/endpoint",
-                    "routingKeys" to listOf("did:example:somemediator#somekey"),
-                    "accept" to listOf("didcomm/v2", "didcomm/aip2;env=rfc587"),
+                    "serviceEndpoint" to mapOf(
+                        "uri" to "https://example.com/endpoint",
+                        "routingKeys" to listOf("did:example:somemediator#somekey"),
+                        "accept" to listOf("didcomm/v2", "didcomm/aip2;env=rfc587"),
+                    )
                 )
             )
+
         )
         val service = decodeService(
             listOf("eyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0"),
             PEER_DID_NUMALGO_2
         )
         assertEquals(expected, service)
+    }
+
+    @Test
+    fun testEncodeServiceEndpointFields() {
+        assertEquals(
+            ".SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHA6Ly9leGFtcGxlLmNvbS9kaWRjb21tIiwiYSI6WyJkaWRjb21tL3YyIl0sInIiOlsiZGlkOmV4YW1wbGU6MTIzNDU2Nzg5YWJjZGVmZ2hpI2tleS0xIl19fQ",
+            encodeService(
+                """
+                        {
+                          "type": "DIDCommMessaging",
+                          "serviceEndpoint": {
+                            "uri": "http://example.com/didcomm",
+                            "accept": [
+                              "didcomm/v2"
+                            ],
+                            "routingKeys": [
+                              "did:example:123456789abcdefghi#key-1"
+                            ]
+                          }
+                        }
+                        """
+            )
+        )
     }
 
     @Test
@@ -58,15 +84,16 @@ class TestServiceEncodeDecode {
             )
         )
     }
-
     @Test
     fun testDecodeServiceMinimalFields() {
         val expected = listOf(
             OtherService(
                 mapOf(
-                    "id" to "$PEER_DID_NUMALGO_2#didcommmessaging-0",
+                    "id" to "#service",
                     "type" to "DIDCommMessaging",
-                    "serviceEndpoint" to "https://example.com/endpoint"
+                    "serviceEndpoint" to mapOf(
+                        "uri" to "https://example.com/endpoint",
+                    )
                 )
             )
         )
@@ -106,19 +133,23 @@ class TestServiceEncodeDecode {
         val expected = listOf(
             OtherService(
                 mapOf(
-                    "id" to "$PEER_DID_NUMALGO_2#didcommmessaging-0",
+                    "id" to "#service",
                     "type" to "DIDCommMessaging",
-                    "serviceEndpoint" to "https://example.com/endpoint",
-                    "routingKeys" to listOf("did:example:somemediator#somekey"),
-                    "accept" to listOf("didcomm/v2", "didcomm/aip2;env=rfc587")
+                    "serviceEndpoint" to mapOf(
+                        "uri" to "https://example.com/endpoint",
+                        "routingKeys" to listOf("did:example:somemediator#somekey"),
+                        "accept" to listOf("didcomm/v2", "didcomm/aip2;env=rfc587")
+                    )
                 )
             ),
             OtherService(
                 mapOf(
-                    "id" to "$PEER_DID_NUMALGO_2#didcommmessaging-1",
+                    "id" to "#service-1",
                     "type" to "DIDCommMessaging",
-                    "serviceEndpoint" to "https://example.com/endpoint2",
-                    "routingKeys" to listOf("did:example:somemediator#somekey2")
+                    "serviceEndpoint" to mapOf(
+                        "uri" to "https://example.com/endpoint2",
+                        "routingKeys" to listOf("did:example:somemediator#somekey2"),
+                    )
                 )
             )
         )
@@ -133,19 +164,23 @@ class TestServiceEncodeDecode {
         val expected = listOf(
             OtherService(
                 mapOf(
-                    "id" to "$PEER_DID_NUMALGO_2#didcommmessaging-0",
+                    "id" to "#service",
                     "type" to "DIDCommMessaging",
-                    "serviceEndpoint" to "https://example.com/endpoint",
-                    "routingKeys" to listOf("did:example:somemediator#somekey"),
-                    "accept" to listOf("didcomm/v2", "didcomm/aip2;env=rfc587")
+                    "serviceEndpoint" to mapOf(
+                        "uri" to "https://example.com/endpoint",
+                        "routingKeys" to listOf("did:example:somemediator#somekey"),
+                        "accept" to listOf("didcomm/v2", "didcomm/aip2;env=rfc587")
+                    )
                 )
             ),
             OtherService(
                 mapOf(
-                    "id" to "$PEER_DID_NUMALGO_2#didcommmessaging-1",
+                    "id" to "#service-1",
                     "type" to "DIDCommMessaging",
-                    "serviceEndpoint" to "https://example.com/endpoint2",
-                    "routingKeys" to listOf("did:example:somemediator#somekey2")
+                    "serviceEndpoint" to mapOf(
+                        "uri" to "https://example.com/endpoint2",
+                        "routingKeys" to listOf("did:example:somemediator#somekey2"),
+                    )
                 )
             )
         )


### PR DESCRIPTION
https://identity.foundation/peer-did-method-spec

This PR updates the peer-did JVM library to align with the latest specifications for creating and resolving peer DIDs. It ensures compatibility with both current and new methods of specifying the service field in a peer DID.
The PR accommodates two formats for defining the service field in the peer DID creation process. The first format is as follows:

```
{
	"type": "DIDCommMessaging",
	"serviceEndpoint": "https://example.com/endpoint1",
	"routingKeys": ["did:example:somemediator#somekey1"],
	"accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"]
}
```
Using this format, a peer DID similar to the one below is created:

did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDEiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MSJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfQ

The second format, as per the new peer DID spec, is as follows:

```
{
  "type": "DIDCommMessaging",
  "serviceEndpoint": {
    "uri": "https://example.com/endpoint1",
    "routingKeys": [
      "did:example:somemediator#somekey1"
    ],
    "accept": [
      "didcomm/v2",
      "didcomm/aip2;env=rfc587"
    ]
  }
}
```
This results in a peer DID like this:

did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19

In both cases, the resolution of the peer DID will conform to the new peer DID specification, producing a resolved DID document similar to the following:

```
{
  "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19",
  "authentication": [
    {
      "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19#key-2",
      "type": "Ed25519VerificationKey2020",
      "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19",
      "publicKeyMultibase": "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
    }
  ],
  "keyAgreement": [
    {
      "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19#key-1",
      "type": "X25519KeyAgreementKey2020",
      "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19",
      "publicKeyMultibase": "z6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud"
    }
  ],
  "service": [
    {
      "id": "#service",
      "type": "DIDCommMessaging",
      "serviceEndpoint": {
        "uri": "https://example.com/endpoint1",
        "routingKeys": [
          "did:example:somemediator#somekey1"
        ],
        "accept": [
          "didcomm/v2",
          "didcomm/aip2;env=rfc587"
        ]
      }
    }
  ]
}
```

Tests have been added and updated to support both described cases, ensuring that the peer DID creation and resolution process is in line with the new peer DID specification.