### PR TITLE
Preserve all legacy service properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ out/
 *.DS_Store
 .DS_Store
 .DS_Store?
+local.properties
 
 ### NetBeans ###
 /nbproject/private/

--- a/lib/src/main/kotlin/org/didcommx/peerdid/core/PeerDIDHelper.kt
+++ b/lib/src/main/kotlin/org/didcommx/peerdid/core/PeerDIDHelper.kt
@@ -154,6 +154,11 @@ internal fun decodeService(encodedServices: List<JSON>, peerDID: PeerDID): List<
             "type" to serviceType,
             "serviceEndpoint" to serviceEndpointMap
         )
+        serviceMap.map { (key, value) ->
+            if (!ServicePrefix.containsValue(key) && key != "id") {
+                service[key] = value
+            }
+        }
         OtherService(service)
     }.toList()
 }

--- a/lib/src/test/kotlin/org/didcommx/peerdid/Fixture.kt
+++ b/lib/src/test/kotlin/org/didcommx/peerdid/Fixture.kt
@@ -367,3 +367,44 @@ const val DID_DOC_NUMALGO_2_MULTIBASE_MINIMAL_SERVICES = """
            ]
        }
     """
+
+const val PEER_DID_NUMALGO_2_LEGACY_SERVICES = "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZGlkLWNvbW11bmljYXRpb24iLCJpZCI6IiNzZXJ2aWNlLTEiLCJzIjoiZGlkY29tbTp0cmFuc3BvcnQvcXVldWUiLCJyZWNpcGllbnRLZXlzIjpbIiNrZXktMiJdLCJyIjpbXX0"
+
+const val DID_DOC_NUMALGO_2_MULTIBASE_LEGACY_SERVICES = """
+        {
+           "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZGlkLWNvbW11bmljYXRpb24iLCJpZCI6IiNzZXJ2aWNlLTEiLCJzIjoiZGlkY29tbTp0cmFuc3BvcnQvcXVldWUiLCJyZWNpcGllbnRLZXlzIjpbIiNrZXktMiJdLCJyIjpbXX0",
+           "authentication": [
+               {
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZGlkLWNvbW11bmljYXRpb24iLCJpZCI6IiNzZXJ2aWNlLTEiLCJzIjoiZGlkY29tbTp0cmFuc3BvcnQvcXVldWUiLCJyZWNpcGllbnRLZXlzIjpbIiNrZXktMiJdLCJyIjpbXX0#key-2",
+                   "type": "Ed25519VerificationKey2020",
+                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZGlkLWNvbW11bmljYXRpb24iLCJpZCI6IiNzZXJ2aWNlLTEiLCJzIjoiZGlkY29tbTp0cmFuc3BvcnQvcXVldWUiLCJyZWNpcGllbnRLZXlzIjpbIiNrZXktMiJdLCJyIjpbXX0",
+                   "publicKeyMultibase": "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+               },
+               {
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZGlkLWNvbW11bmljYXRpb24iLCJpZCI6IiNzZXJ2aWNlLTEiLCJzIjoiZGlkY29tbTp0cmFuc3BvcnQvcXVldWUiLCJyZWNpcGllbnRLZXlzIjpbIiNrZXktMiJdLCJyIjpbXX0#key-3",
+                   "type": "Ed25519VerificationKey2020",
+                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZGlkLWNvbW11bmljYXRpb24iLCJpZCI6IiNzZXJ2aWNlLTEiLCJzIjoiZGlkY29tbTp0cmFuc3BvcnQvcXVldWUiLCJyZWNpcGllbnRLZXlzIjpbIiNrZXktMiJdLCJyIjpbXX0",
+                   "publicKeyMultibase": "z6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg"
+               }
+           ],
+           "keyAgreement": [
+               {
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZGlkLWNvbW11bmljYXRpb24iLCJpZCI6IiNzZXJ2aWNlLTEiLCJzIjoiZGlkY29tbTp0cmFuc3BvcnQvcXVldWUiLCJyZWNpcGllbnRLZXlzIjpbIiNrZXktMiJdLCJyIjpbXX0#key-1",
+                   "type": "X25519KeyAgreementKey2020",
+                   "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZGlkLWNvbW11bmljYXRpb24iLCJpZCI6IiNzZXJ2aWNlLTEiLCJzIjoiZGlkY29tbTp0cmFuc3BvcnQvcXVldWUiLCJyZWNpcGllbnRLZXlzIjpbIiNrZXktMiJdLCJyIjpbXX0",
+                   "publicKeyMultibase": "z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc"
+               }
+           ],
+           "service": [
+               {
+                    "id": "#service",
+                    "type": "did-communication",
+                    "serviceEndpoint": {
+                        "uri": "didcomm:transport/queue",
+                        "routingKeys": []
+                    },
+                    "recipientKeys": ["#key-2"]
+                }
+           ]
+       }
+    """

--- a/lib/src/test/kotlin/org/didcommx/peerdid/TestResolveNumalgo2.kt
+++ b/lib/src/test/kotlin/org/didcommx/peerdid/TestResolveNumalgo2.kt
@@ -56,6 +56,12 @@ class TestResolveNumalgo2 {
     }
 
     @Test
+    fun testResolvePositiveLegacyService() {
+        val realValue = resolvePeerDID(PEER_DID_NUMALGO_2_LEGACY_SERVICES)
+        assertEquals(fromJson(DID_DOC_NUMALGO_2_MULTIBASE_LEGACY_SERVICES), fromJson(realValue))
+    }
+
+    @Test
     fun testResolveUnsupportedNumalgoCode() {
         val ex = assertThrows<MalformedPeerDIDException> {
             resolvePeerDID(


### PR DESCRIPTION
Currently, this library is dropping all properties except `id`, `type`, and `serviceEndpoint` from the service objects.
For example,
```json
{
  "type": "did-communication",
  "id": "#service-1",
  "serviceEndpoint": "didcomm:transport/queue",
  "recipientKeys": [
    "#key-2"
  ],
  "routingKeys": []
}
```
is parsed as follows:
```json
{
  "id": "#service",
  "type": "did-communication",
  "serviceEndpoint": {
    "uri": "didcomm:transport/queue",
    "routingKeys": []
  }
}
```
`recipientKeys` is omitted in this case.

This commit keeps these properties and parses the service as follows:
```json
{
  "id": "#service",
  "type": "did-communication",
  "serviceEndpoint": {
    "uri": "didcomm:transport/queue",
    "routingKeys": []
  },
  "recipientKeys": [
    "#key-2"
  ]
}
```